### PR TITLE
lib: rollback to innosetup 6.2.2

### DIFF
--- a/.build/libs/innosetup.properties
+++ b/.build/libs/innosetup.properties
@@ -1,4 +1,4 @@
-innosetup.version = 6.3.3
+innosetup.version = 6.2.2
 innosetup.url = http://files.jrsoftware.org/is/6/innosetup-${innosetup.version}.exe
 
 innosetup.comp = lzma2/normal


### PR DESCRIPTION
innoextract does not support innosetup 6.3.0:

```
     [exec] Done with 1 error and 4 warnings.
     [exec] Warning: Unexpected setup data version: 6.3.0
     [exec] Warning: Unexpected Style value: 77
     [exec] Warning: Unexpected Uninstall Log Mode value: 18
     [exec] Warning: Unexpected Auto Boolean value: 3
     [exec] Stream error while parsing setup headers!
     [exec]  Ôö£ÔöÇ detected setup version: 6.3.0
     [exec]  ÔööÔöÇ error reason: basic_ios::clear: iostream error
     [exec] If you are sure the setup file is not corrupted, consider
     [exec] filing a bug report at https://innoextract.constexpr.org/issues
```